### PR TITLE
chore: coveralls로 test coverage 업로드 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         if: failure()
         run: echo "Test coverage가 70% 미만입니다"
 
-      # Codecov에 커버리지 리포트 업로드
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+      # Coveralls에 커버리지 리포트 업로드
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,13 @@ jobs:
 
       - run: npm install
 
-      # 테스트 및 커버리지 리포트 생성
       - name: Run tests with coverage
         run: npm run test:cov
 
-      # 실패 시 메시지 출력
       - name: Check test failure
         if: failure()
         run: echo "Test coverage가 70% 미만입니다"
 
-      # Coveralls에 커버리지 리포트 업로드
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2
         with:


### PR DESCRIPTION
## 추가한 기능 설명

원래 codecov로 구현하려고 했는데, 저희가 team organization로 유료버전이랍니다..
그래서 무료로 사용가능한 coveralls로 test coverage를 그래프로 시각화 할 수 있는 툴을 이용해 ci에 적용했습니다.

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
