### PR TITLE
Refactor/#28 토글 좋아요의 동시성을 해결

### DIFF
--- a/src/config/redis/redis.service.ts
+++ b/src/config/redis/redis.service.ts
@@ -10,28 +10,6 @@ export class RedisService {
         this.redisClient = redisService.getClient();
     }
 
-    // async setValues(key: string, data: string): Promise<string>{
-    //     await this.redisClient.set(key, data);
-    //     return `Redis에 key가 생성됨`;
-    // }
-
-    // async setValuesList(key: string, data: string): Promise<number>{
-    //     return await this.redisClient.rpush(key, data);
-    // }
-
-    // async getValues(key: string): Promise<string|null>{
-    //     return await this.redisClient.get(key);
-    // }
-
-    // async getValuesList(key: string): Promise<string[]>{
-    //     const len = await this.redisClient.llen(key);
-    //     return len === 0 ? [] : await this.redisClient.lrange(key, 0, len-1);
-    // }
-
-    // async deleteValuesList(key: string, data: string): Promise<number>{
-    //     return await this.redisClient.lrem(key, 0, data);
-    // }
-
     async boardLikesInc(key: string): Promise<number>{
         return await this.redisClient.incr(key);
     }

--- a/src/config/redis/redis.service.ts
+++ b/src/config/redis/redis.service.ts
@@ -10,25 +10,45 @@ export class RedisService {
         this.redisClient = redisService.getClient();
     }
 
-    async setValues(key: string, data: string): Promise<string>{
-        await this.redisClient.set(key, data);
-        return `Redis에 key가 생성됨`;
+    // async setValues(key: string, data: string): Promise<string>{
+    //     await this.redisClient.set(key, data);
+    //     return `Redis에 key가 생성됨`;
+    // }
+
+    // async setValuesList(key: string, data: string): Promise<number>{
+    //     return await this.redisClient.rpush(key, data);
+    // }
+
+    // async getValues(key: string): Promise<string|null>{
+    //     return await this.redisClient.get(key);
+    // }
+
+    // async getValuesList(key: string): Promise<string[]>{
+    //     const len = await this.redisClient.llen(key);
+    //     return len === 0 ? [] : await this.redisClient.lrange(key, 0, len-1);
+    // }
+
+    // async deleteValuesList(key: string, data: string): Promise<number>{
+    //     return await this.redisClient.lrem(key, 0, data);
+    // }
+
+    async boardLikesInc(key: string): Promise<number>{
+        return await this.redisClient.incr(key);
     }
 
-    async setValuesList(key: string, data: string): Promise<number>{
-        return await this.redisClient.rpush(key, data);
+    async boardLikesDec(key: string): Promise<number>{
+        return await this.redisClient.decr(key);
     }
 
-    async getValues(key: string): Promise<string|null>{
-        return await this.redisClient.get(key);
+    async addUserLikesSet(key: string, value: string): Promise<number>{
+        return await this.redisClient.sadd(key, value);
     }
 
-    async getValuesList(key: string): Promise<string[]>{
-        const len = await this.redisClient.llen(key);
-        return len === 0 ? [] : await this.redisClient.lrange(key, 0, len-1);
+    async removeUserLikesSet(key: string, value: string): Promise<number>{
+        return await this.redisClient.srem(key, value);
     }
 
-    async deleteValuesList(key: string, data: string): Promise<number>{
-        return await this.redisClient.lrem(key, 0, data);
+    async isUserIncludeSet(key: string, value: string): Promise<boolean>{
+        return await this.redisClient.sismember(key, value) ===1 ;
     }
 }

--- a/src/modules/board/board.service.ts
+++ b/src/modules/board/board.service.ts
@@ -193,32 +193,5 @@ export class BoardService {
     isBoardExist.likesCount = boardLikes;
     await this.boardRepository.save(isBoardExist);
     return isBoardExist;
-
-
-
-
-
-    // // 게시물 좋아요 key의 value를 확인해 value가 있으면 그냥 반환, 없으면 0해줌
-    // let boardLikesValue = await this.redisService.getValues(redisBoardKey); // boardLikesValue는 string임
-    // if(boardLikesValue === null){
-    //   await this.redisService.setValues(redisBoardKey, '0');
-    //   boardLikesValue = '0';
-    // }
-    // // 해당 유저가 게시물에 좋아요를 누른 list 가져오기
-    // const userBoardLikes = await this.redisService.getValuesList(redisUserKey);
-    // let boardLikes = parseInt(boardLikesValue); // Int로 변환
-    // if(!userBoardLikes.includes(boardId.toString())){ // 해당 유저가 해당 게시물에 좋아요를 누르지 않았다면
-    //   boardLikes++; // 좋아요 카운트 증가
-    //   await this.redisService.setValuesList(redisUserKey, boardId.toString()); // 해당 유저가 게시물에 좋아요를 눌렀음을 알려주도록 set
-    // }else{ // 해당 유저가 게시물에 좋아요를 눌렀다면
-    //   boardLikes--; // 좋아요 카운트 감소
-    //   await this.redisService.deleteValuesList(redisUserKey, boardId.toString()); // 해당 유저가 게시물에서 좋아요를 해제함을 알려주도록 set
-    // }
-    // // 게시물 좋아요 key에 좋아요 카운트를 반영
-    // await this.redisService.setValues(redisBoardKey, boardLikes.toString());
-    // // db에 좋아요카운트 업데이트
-    // isBoardExist.likesCount = boardLikes;
-    // await this.boardRepository.save(isBoardExist);
-    // return isBoardExist;
   }
 }

--- a/src/modules/board/entity/board.entity.ts
+++ b/src/modules/board/entity/board.entity.ts
@@ -27,9 +27,6 @@ export class Board extends BaseEntity {
   @Column({ nullable: true })
   imageUrl: string;
 
-  @VersionColumn()
-  version: number;
-
   @ManyToOne((type) => User)
   @JoinColumn({ name: 'user_id' })
   creator: User;

--- a/src/modules/board/entity/board.entity.ts
+++ b/src/modules/board/entity/board.entity.ts
@@ -1,7 +1,7 @@
 import { User } from '../../user/entity/user.entity';
 import { BaseEntity } from '../../../global/common/base.entitiy';
 import { StuffCategory } from '../enums/stuffCategory.enum';
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, VersionColumn } from 'typeorm';
 import { Comment } from '../../comment/entity/comment.entity';
 
 @Entity()
@@ -26,6 +26,9 @@ export class Board extends BaseEntity {
 
   @Column({ nullable: true })
   imageUrl: string;
+
+  @VersionColumn()
+  version: number;
 
   @ManyToOne((type) => User)
   @JoinColumn({ name: 'user_id' })


### PR DESCRIPTION
## 추가한 기능 설명
Lock을 사용하여 동시성을 해결하려고 했으나 아래와 같은 문제가 생겼습니다.

1) 낙관적 락: 원래 이 방법으로 동시성을 해결하려고 했습니다. 하지만 낙관적 락 같은 경우에는 동시성 문제가 터질때마다 OptimisticLockVersionMismatchError 를 발생시켜서 rollback 시키기때문에, 실패시마다 재시도를 계속 해줘야 하는 문제가 있습니다. 즉 재시도가 잦다면 DB에 부하가 올 수 있다 판단하여 낙관적 락을 사용하지 않기로 하였습니다.

2) 비관적 락(in 배타 락): 비관적 락은 하나의 트랜잭션이 실행될 때마다 락을 걸어두기 때문에 동시성 문제를 확실히 막을 수는 있지만, 동시에 여러 트랜잭션이 하나의 자원에 접근할 수 없기때문에 좋아요 같은 기능에서 상당한 성능 저하가 발생한다 생각하여 고려하지 않았습니다.

--> [해결 방법]: Redis로 동시성을 해결

위와 같은 이유로 Redis로 동시성을 처리했습니다. 
1) Redis는 단일스레드이기 때문에 여러 트랜잭션들이 접근하더라도 순차적으로 작업을 처리합니다. 즉, 동시성 문제를 해결할 수 있습니다.
2) Redis는 메모리 기반이기 때문에 네트워크 기반인 락보다 훨씬 빠른 성능을 가집니다.


[추후 추가 할 내용]
1) Redis에 Replication과 Clustor 추가


<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
