### PR TITLE
[Feat/#36] AccessToken 만료 시, RefreshToken으로 새로운 AccessToken 발급받는 API 구현

### DIFF
--- a/src/config/redis/refresh-token.service.ts
+++ b/src/config/redis/refresh-token.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+import { RedisService as RedisDao } from "@songkeys/nestjs-redis";
+import { Redis } from "ioredis";
+
+@Injectable()
+export class RefreshTokenService {
+    private readonly redisClient: Redis;
+
+    constructor(private readonly refreshTokenService: RedisDao){
+        this.redisClient = this.refreshTokenService.getClient();
+    }
+
+    async setKey(key: string, value: string, ttl: number): Promise<void> {
+        await this.redisClient.set(key, value, 'EX', ttl);
+    }
+
+    async getKey(key: string): Promise<string|null> {
+        return this.redisClient.get(key);
+    }
+}

--- a/src/global/exception/errorCode/Errorcode.ts
+++ b/src/global/exception/errorCode/Errorcode.ts
@@ -8,6 +8,10 @@ export enum ErrorCode {
     USER_INVALID_PROVINCE = 'U005',
     USER_INVALID_CITY = 'U006',
 
+    // Refresh Token(JWT)
+    REFRESH_TOKEN_INVALID = 'JWT001',
+    REFRESH_TOKEN_EXPIRED = 'JWT002',
+
     //Region
     PARENT_REGION_NOT_FOUND = 'R001',
     REGION_NOT_FOUND = 'R002',

--- a/src/interfaces/user-login-result.interface.ts
+++ b/src/interfaces/user-login-result.interface.ts
@@ -1,4 +1,5 @@
 export interface UserLoginResultInterface {
     accessToken: string;
+    refreshToken: string;
     regionName: string;
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Post, UseGuards} from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, Res, UseGuards} from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { AuthService} from './auth.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -6,7 +6,8 @@ import { AuthCredentialsDto } from './dto/auth-credentials.dto';
 import { UserCreateResultInterface } from '../../interfaces/user-create-result.interface';
 import { UserId } from '../../decorators/user-id.decorator';
 import { UserLocalAuthGuard } from './guards/user-local.auth.guard';
-import { UserLoginResultInterface } from '../../interfaces/user-login-result.interface';
+import { Response } from 'express';
+
 
 @ApiTags('auth')
 @Controller('auth')
@@ -31,8 +32,17 @@ export class AuthController {
     @Post('/signin')
     async loginUser(
         @Body() authCredentialsDto: AuthCredentialsDto,
-        @UserId() userId: number
-    ): Promise<UserLoginResultInterface>{
-        return this.authService.loginUser(userId);
+        @UserId() userId: number,
+        @Res() res: Response
+    ): Promise<void>{
+        const {accessToken, refreshToken, regionName} = await this.authService.loginUser(userId);
+
+        res.cookie('accessToken', accessToken, {httpOnly: true});
+        res.cookie('refreshToken', refreshToken, {httpOnly: true});
+
+        res.status(201).json({
+            message: '로그인 성공',
+            regionName: regionName
+        });
     }
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import { UserCreateResultInterface } from '../../interfaces/user-create-result.i
 import { UserId } from '../../decorators/user-id.decorator';
 import { UserLocalAuthGuard } from './guards/user-local.auth.guard';
 import { Response } from 'express';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
 
 
 @ApiTags('auth')
@@ -43,6 +44,20 @@ export class AuthController {
         res.status(201).json({
             message: '로그인 성공',
             regionName: regionName
+        });
+    }
+
+    @Post('/refresh')
+    async refreshToken(
+        @Body() refreshTokenDto: RefreshTokenDto,
+        @Res() res: Response
+    ): Promise<void>{
+        const {newAccessToken} = await this.authService.refreshToken(refreshTokenDto);
+
+        res.cookie('newAccessToken', newAccessToken, {httpOnly: true});
+
+        res.status(201).json({
+            message: 'accessToken 갱신 성공'
         });
     }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { PassportModule } from '@nestjs/passport';
 import { UserLocalStrategy } from './strategies/user-local.auth.strategy';
 import { UserJwtStrategy } from './strategies/user-jwt.strategy';
 import { Region } from '../region/entity/region.entity';
+import { RefreshTokenService } from '../../config/redis/refresh-token.service';
 
 @Module({
   imports: [
@@ -28,6 +29,6 @@ import { Region } from '../region/entity/region.entity';
     PassportModule
   ],
   controllers: [AuthController],
-  providers: [AuthService, UserMapper, UserLocalStrategy, UserJwtStrategy]
+  providers: [AuthService, UserMapper, UserLocalStrategy, UserJwtStrategy, RefreshTokenService]
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -94,14 +94,21 @@ export class AuthService {
 
     async loginUser(id: number): Promise<UserLoginResultInterface> {
         const payload: {id: number} = {id};
+
         const accessToken = this.jwtService.sign(payload, {
             secret: this.configService.get('JWT_SECRET_KEY'),
         });
+        const refreshToken = this.jwtService.sign(payload, {
+            secret: this.configService.get('JWT_REFRESH_SECRET_KEY'),
+            expiresIn: this.configService.get('JWT_REFRESH_EXPIRATION')
+        });
+
         const user = await this.userRepository.findOne({where: {id: id}, relations: ['region']});
         const userRegionName = user.region.name;
     
         return {
             accessToken: accessToken,
+            refreshToken: refreshToken,
             regionName: userRegionName,
         };
     }

--- a/src/modules/auth/authException/Login-Invalid-Password-Exception.ts
+++ b/src/modules/auth/authException/Login-Invalid-Password-Exception.ts
@@ -8,6 +8,6 @@ export class LoginInvalidPasswordException extends CustomException {
             ErrorCode.USER_INVALID_PASSWROD,
             '비밀번호가 일치하지 않습니다! 다시 로그인을 해주세요.',
             HttpStatus.UNAUTHORIZED,
-        )
+        );
     }
 }

--- a/src/modules/auth/authException/ParentRegion-Not-Found-Exception.ts
+++ b/src/modules/auth/authException/ParentRegion-Not-Found-Exception.ts
@@ -9,6 +9,6 @@ export class ParentRegionNotFoundException extends CustomException {
             ErrorCode.PARENT_REGION_NOT_FOUND,
             '없는 상위 지역명입니다!',
             HttpStatus.NOT_FOUND,
-        )
+        );
     }
 }

--- a/src/modules/auth/authException/RefreshToken-Expired-Exception.ts
+++ b/src/modules/auth/authException/RefreshToken-Expired-Exception.ts
@@ -1,0 +1,13 @@
+import { HttpStatus } from "@nestjs/common";
+import { CustomException } from "../../../global/exception/customException";
+import { ErrorCode } from "../../../global/exception/errorCode/Errorcode";
+
+export class RefreshTokenExpiredException extends CustomException {
+    constructor(){
+        super(
+            ErrorCode.REFRESH_TOKEN_EXPIRED,
+            'Refresh Token이 만료되었습니다! 다시 로그인해주세요.',
+            HttpStatus.UNAUTHORIZED,
+        );
+    }
+}

--- a/src/modules/auth/authException/RefreshToken-Invalid-Exception.ts
+++ b/src/modules/auth/authException/RefreshToken-Invalid-Exception.ts
@@ -1,0 +1,13 @@
+import { HttpStatus } from "@nestjs/common";
+import { CustomException } from "../../../global/exception/customException";
+import { ErrorCode } from "../../../global/exception/errorCode/Errorcode";
+
+export class RefreshTokenInvalidException extends CustomException {
+    constructor(){
+        super(
+            ErrorCode.REFRESH_TOKEN_INVALID,
+            '유효하지 않는 Refresh Token 입니다!',
+            HttpStatus.UNAUTHORIZED,
+        );
+    }
+}

--- a/src/modules/auth/dto/refresh-token.dto.ts
+++ b/src/modules/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmptyAndString } from "src/decorators/is-Not-Empty-And-String.decorator";
+
+export class RefreshTokenDto{
+
+    @IsNotEmptyAndString()
+    refreshToken: string;
+}


### PR DESCRIPTION
## 요약
RefreshToken을 추가하며 AccessToken의 유효시간을 1시간, RefreshToken의 유효시간을 하루로 설정했습니다. RefreshToken 저장소로 사용중인 MySQL에 저장할 지 Redis에 저장할 지 고민을 했으나, Redis에 저장한 이유는 아래와 같습니다.

1) 인메모리DB인 Redis는 다른 DB보다 조회속도가 빠르다.
2) 내가 사용하려 했던 MySQL은 RefreshToken을 만료시키기 위해 scheduler나 직접 삭제를 시켜야 하는 데, Redis는 휘발성 DB이기 때문에 TTL을 설정하면 자동으로 삭제가 된다.


## 추가한 기능 설명
<br>

1. 클라이언트에게 전달되는 Refresh, AccessToken을 Json -> Cookie 로 변경했습니다.
2. 로그인 시 생성되는 Refresh, AccessToken 중에 서버에서는 Redis에 RefreshToken을 저장했습니다.
3. Redis의 RefreshToken의 TTL은 24시간(86400초)로 설정했습니다.
4. Refresh로 AccessToken을 갱신 시, Redis에 RefreshToken이 만료되어 Null인경우, 클라이언트의 RefreshToken이 Redis의 RefreshToken과 일치하지 않는 경우 예외처리를 했습니다.

## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
